### PR TITLE
Adding bound interceptors for axios.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/svrcekmichal/redux-axios-middleware/issues"
   },
   "homepage": "https://github.com/svrcekmichal/redux-axios-middleware",
+  "peerDependencies": {
+    "axios": ">= 0.5"
+  },
   "devDependencies": {
     "babel-cli": "^6.5.1",
     "babel-eslint": "^6.0.2",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,11 +1,31 @@
 import * as defaultOptions from './defaults';
 import { getActionTypes } from './getActionTypes';
+import axios from 'axios';
+
+let interceptorsBound = false;
+
+function bindInterceptors(getState, { requestInterceptors = [], responseInterceptors = [] } = {}) {
+  requestInterceptors.forEach((interceptor) => {
+    axios.interceptors.request.use(interceptor.bind(null, getState));
+  });
+
+  responseInterceptors.forEach((interceptor) => {
+    axios.interceptors.response.use(interceptor.bind(null, getState));
+  });
+
+  interceptorsBound = true;
+}
 
 export default (client, userOptions = {}) => {
   const options = { ...defaultOptions, ...userOptions };
+
   return ({ getState, dispatch }) => next => action => {
     if (!options.isAxiosRequest(action)) {
       return next(action);
+    }
+
+    if (options.interceptors && !interceptorsBound) {
+      bindInterceptors(getState, options.interceptors);
     }
     const [REQUEST] = getActionTypes(action, options);
     next({ ...action, type: REQUEST });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,16 +1,15 @@
 import * as defaultOptions from './defaults';
 import { getActionTypes } from './getActionTypes';
-import axios from 'axios';
 
 let interceptorsBound = false;
 
-function bindInterceptors(getState, { requestInterceptors = [], responseInterceptors = [] } = {}) {
+function bindInterceptors(client, getState, { requestInterceptors = [], responseInterceptors = [] } = {}) {
   requestInterceptors.forEach((interceptor) => {
-    axios.interceptors.request.use(interceptor.bind(null, getState));
+    client.interceptors.request.use(interceptor.bind(null, getState));
   });
 
   responseInterceptors.forEach((interceptor) => {
-    axios.interceptors.response.use(interceptor.bind(null, getState));
+    client.interceptors.response.use(interceptor.bind(null, getState));
   });
 
   interceptorsBound = true;
@@ -25,7 +24,7 @@ export default (client, userOptions = {}) => {
     }
 
     if (options.interceptors && !interceptorsBound) {
-      bindInterceptors(getState, options.interceptors);
+      bindInterceptors(client, getState, options.interceptors);
     }
     const [REQUEST] = getActionTypes(action, options);
     next({ ...action, type: REQUEST });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,12 +3,12 @@ import { getActionTypes } from './getActionTypes';
 
 let interceptorsBound = false;
 
-function bindInterceptors(client, getState, { requestInterceptors = [], responseInterceptors = [] } = {}) {
-  requestInterceptors.forEach((interceptor) => {
+function bindInterceptors(client, getState, { request = [], response = [] } = {}) {
+  request.forEach((interceptor) => {
     client.interceptors.request.use(interceptor.bind(null, getState));
   });
 
-  responseInterceptors.forEach((interceptor) => {
+  response.forEach((interceptor) => {
     client.interceptors.response.use(interceptor.bind(null, getState));
   });
 


### PR DESCRIPTION
After looking around I thought your setup worked the best as an Axios middleware with Redux.  It was missing one thing I needed.  I needed the ability to add headers based on the Redux state.  The best way I could think of was to have an Axios interceptor that had access to the state.

In this PR it gives you the ability to define options like the following.

```
userOptions = {
  interceptors: {
    requestInterceptors = [...],
    responseInterceptors = [...]
  }
}
```

These interceptors would have the `getState` function added to their parameters.

Let me know your thoughts or if you have a better idea.