### PR TITLE
Don't prepend success/error suffixes with "_"

### DIFF
--- a/src/getActionTypes.js
+++ b/src/getActionTypes.js
@@ -1,5 +1,5 @@
-export const SUCCESS_SUFFIX = 'SUCCESS';
-export const ERROR_SUFFIX = 'FAIL';
+export const SUCCESS_SUFFIX = '_SUCCESS';
+export const ERROR_SUFFIX = '_FAIL';
 
 export const getActionTypes = (action, {
   errorSuffix = ERROR_SUFFIX,
@@ -8,7 +8,7 @@ export const getActionTypes = (action, {
   let types;
   if (typeof action.type !== 'undefined') {
     const { type } = action;
-    types = [type, `${type}_${successSuffix}`, `${type}_${errorSuffix}`];
+    types = [type, `${type}${successSuffix}`, `${type}${errorSuffix}`];
   } else if (typeof action.types !== 'undefined') {
     types = action.types;
   } else {

--- a/test/getActionTypes.js
+++ b/test/getActionTypes.js
@@ -8,8 +8,8 @@ describe('getActionTypes', () => {
     const types = getActionTypes(action);
     expect(types).to.be.array;
     expect(types[0]).to.equal(action.type);
-    expect(types[1]).to.equal(`${action.type}_${SUCCESS_SUFFIX}`);
-    expect(types[2]).to.equal(`${action.type}_${ERROR_SUFFIX}`);
+    expect(types[1]).to.equal(`${action.type}${SUCCESS_SUFFIX}`);
+    expect(types[2]).to.equal(`${action.type}${ERROR_SUFFIX}`);
   });
 
   it('should return custom types with `types` key', () => {
@@ -35,27 +35,27 @@ describe('getActionTypes', () => {
 
   it('should use custom success sufix if defined', () => {
     const action = {type:'TYPE'};
-    const types = getActionTypes(action, {successSuffix:'AWESOME'});
+    const types = getActionTypes(action, {successSuffix:'_AWESOME'});
     expect(types).to.be.array;
     expect(types[0]).to.equal(action.type);
     expect(types[1]).to.equal(`${action.type}_AWESOME`);
-    expect(types[2]).to.equal(`${action.type}_${ERROR_SUFFIX}`);
+    expect(types[2]).to.equal(`${action.type}${ERROR_SUFFIX}`);
   });
 
   it('should use custom error sufix if defined', () => {
     const action = {type:'TYPE'};
-    const types = getActionTypes(action, {errorSuffix:'OH_NO'});
+    const types = getActionTypes(action, {errorSuffix:'_OH_NO'});
     expect(types).to.be.array;
     expect(types[0]).to.equal(action.type);
-    expect(types[1]).to.equal(`${action.type}_${SUCCESS_SUFFIX}`);
+    expect(types[1]).to.equal(`${action.type}${SUCCESS_SUFFIX}`);
     expect(types[2]).to.equal(`${action.type}_OH_NO`);
   });
 
   it('should use custom success and error sufix if defined', () => {
     const action = {type:'TYPE'};
     const types = getActionTypes(action,{
-      successSuffix:'AWESOME',
-      errorSuffix:'OH_NO'
+      successSuffix:'_AWESOME',
+      errorSuffix:'_OH_NO'
     });
     expect(types).to.be.array;
     expect(types[0]).to.equal(action.type);
@@ -64,7 +64,3 @@ describe('getActionTypes', () => {
   });
 
 });
-
-
-
-


### PR DESCRIPTION
This might be nitpicking but it would allow for "cleaner" action types.
I would like to remove that extra "_":

![screen shot](https://cloud.githubusercontent.com/assets/3869532/17941653/decc2840-69f9-11e6-8efd-dd4566b197f2.png)
