### PR TITLE
[Proposal] add a cancellable option

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -29,7 +29,6 @@ export const multiClientMiddleware = (clients, customMiddlewareOptions) => {
       return next(action);
     }
 
-    // Cancellable
     if (action.payload.cancellable) {
       const requestId = typeof requests[action.type] !== 'undefined' ? requests[action.type] + 1 : 1;
       actionRequestId = requestId;
@@ -58,7 +57,6 @@ export const multiClientMiddleware = (clients, customMiddlewareOptions) => {
     return setupedClient.client.request(actionOptions.getRequestConfig(action))
       .then(
         (response) => {
-          // Cancellable
           if (action.payload.cancellable) {
             if (actionRequestId !== requests[action.type]) {
               if (process && process.env && process.env.NODE_ENV === 'development') {
@@ -73,7 +71,6 @@ export const multiClientMiddleware = (clients, customMiddlewareOptions) => {
           return newAction;
         },
         (error) => {
-          // Cancellable
           if (action.payload.cancellable) {
             if (actionRequestId !== requests[action.type]) {
               if (process && process.env && process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Hello! This PR is trying to resolve an issue that I have with multiple concurrent actions that could be fired by the user, and the need to forward to the store only the result of the last one fired to avoid that the UI and the store will end out of sync.

The only change needed to made an action cancellable will be to add a `cancellable` attribute set to `true` to the action's payload object.

``` javascript
function requestPosts(filters) {
    return {
        type: actions.POSTS_REQUEST,
        payload: {
            request: {
                url: '/posts',
                params: filters
            },
            cancellable: true
        }
    };
}
```

The implementation may be a little naive (works for my case though) and could be improved, but that could be a starting point to implement such funcionality. Thanks for your time, I hope that this PR makes sense, my english is not very good :/
