### PR TITLE
add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src
+.babelrc


### PR DESCRIPTION
This helps if you're trying to use redux-axios-middleware with React Native.

https://github.com/reactjs/redux/issues/1033