### PR TITLE
Add support for initial request suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let store = createStore(
   applyMiddleware(
     //all middlewares
     ...
-    axiosMiddleware(client), //second parameter options can optionally contain onSuccess, onError, onComplete, successSuffix, errorSuffix
+    axiosMiddleware(client), //second parameter options can optionally contain onSuccess, onError, onComplete, successSuffix, errorSuffix, requestSuffix
     ...
   )
 )
@@ -233,6 +233,7 @@ key                          | type                                 | default va
 ---------------------------- | ------------------------------------ | --------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 successSuffix                | string                               | SUCCESS                                                   | `M` `C` `A`  | default suffix added to success action, for example `{type:"READ"}` will be `{type:"READ_SUCCESS"}`
 errorSuffix                  | string                               | FAIL                                                      | `M` `C` `A`  | same as above
+requestSuffix                | string                               |                                                           | `M` `C` `A`  | same as above
 onSuccess                    | function                             | described above                                           | `M` `C` `A`  | function called if axios resolve with success
 onError                      | function                             | described above                                           | `M` `C` `A`  | function called if axios resolve with error
 onComplete                   | function                             | described above                                           | `M` `C` `A`  | function called after axios resolve

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -16,9 +16,9 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -73,7 +73,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 4);
+/******/ 	return __webpack_require__(__webpack_require__.s = 3);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -86,11 +86,14 @@ return /******/ (function(modules) { // webpackBootstrap
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+var REQUEST_SUFFIX = exports.REQUEST_SUFFIX = '';
 var SUCCESS_SUFFIX = exports.SUCCESS_SUFFIX = '_SUCCESS';
 var ERROR_SUFFIX = exports.ERROR_SUFFIX = '_FAIL';
 
 var getActionTypes = exports.getActionTypes = function getActionTypes(action) {
   var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref$requestSuffix = _ref.requestSuffix,
+      requestSuffix = _ref$requestSuffix === undefined ? REQUEST_SUFFIX : _ref$requestSuffix,
       _ref$errorSuffix = _ref.errorSuffix,
       errorSuffix = _ref$errorSuffix === undefined ? ERROR_SUFFIX : _ref$errorSuffix,
       _ref$successSuffix = _ref.successSuffix,
@@ -100,7 +103,7 @@ var getActionTypes = exports.getActionTypes = function getActionTypes(action) {
   if (typeof action.type !== 'undefined') {
     var type = action.type;
 
-    types = [type, '' + type + successSuffix, '' + type + errorSuffix];
+    types = ['' + type + requestSuffix, '' + type + successSuffix, '' + type + errorSuffix];
   } else if (typeof action.types !== 'undefined') {
     types = action.types;
   } else {
@@ -307,10 +310,65 @@ var onError = exports.onError = function onError(_ref2, options) {
 };
 
 var onComplete = exports.onComplete = function onComplete() {};
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(3)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(4)))
 
 /***/ }),
 /* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _middleware = __webpack_require__(1);
+
+Object.defineProperty(exports, 'default', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_middleware).default;
+  }
+});
+Object.defineProperty(exports, 'multiClientMiddleware', {
+  enumerable: true,
+  get: function get() {
+    return _middleware.multiClientMiddleware;
+  }
+});
+
+var _getActionTypes = __webpack_require__(0);
+
+Object.defineProperty(exports, 'getActionTypes', {
+  enumerable: true,
+  get: function get() {
+    return _getActionTypes.getActionTypes;
+  }
+});
+Object.defineProperty(exports, 'REQUEST_SUFFIX', {
+  enumerable: true,
+  get: function get() {
+    return _getActionTypes.REQUEST_SUFFIX;
+  }
+});
+Object.defineProperty(exports, 'ERROR_SUFFIX', {
+  enumerable: true,
+  get: function get() {
+    return _getActionTypes.ERROR_SUFFIX;
+  }
+});
+Object.defineProperty(exports, 'SUCCESS_SUFFIX', {
+  enumerable: true,
+  get: function get() {
+    return _getActionTypes.SUCCESS_SUFFIX;
+  }
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/***/ }),
+/* 4 */
 /***/ (function(module, exports) {
 
 // shim for using process in browser
@@ -483,6 +541,10 @@ process.off = noop;
 process.removeListener = noop;
 process.removeAllListeners = noop;
 process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function (name) { return [] }
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');
@@ -494,55 +556,6 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-
-/***/ }),
-/* 4 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
-var _middleware = __webpack_require__(1);
-
-Object.defineProperty(exports, 'default', {
-  enumerable: true,
-  get: function get() {
-    return _interopRequireDefault(_middleware).default;
-  }
-});
-Object.defineProperty(exports, 'multiClientMiddleware', {
-  enumerable: true,
-  get: function get() {
-    return _middleware.multiClientMiddleware;
-  }
-});
-
-var _getActionTypes = __webpack_require__(0);
-
-Object.defineProperty(exports, 'getActionTypes', {
-  enumerable: true,
-  get: function get() {
-    return _getActionTypes.getActionTypes;
-  }
-});
-Object.defineProperty(exports, 'ERROR_SUFFIX', {
-  enumerable: true,
-  get: function get() {
-    return _getActionTypes.ERROR_SUFFIX;
-  }
-});
-Object.defineProperty(exports, 'SUCCESS_SUFFIX', {
-  enumerable: true,
-  get: function get() {
-    return _getActionTypes.SUCCESS_SUFFIX;
-  }
-});
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /***/ })
 /******/ ]);

--- a/src/getActionTypes.js
+++ b/src/getActionTypes.js
@@ -1,14 +1,16 @@
+export const REQUEST_SUFFIX = '';
 export const SUCCESS_SUFFIX = '_SUCCESS';
 export const ERROR_SUFFIX = '_FAIL';
 
 export const getActionTypes = (action, {
+  requestSuffix = REQUEST_SUFFIX,
   errorSuffix = ERROR_SUFFIX,
   successSuffix = SUCCESS_SUFFIX
 } = {}) => {
   let types;
   if (typeof action.type !== 'undefined') {
     const { type } = action;
-    types = [type, `${type}${successSuffix}`, `${type}${errorSuffix}`];
+    types = [`${type}${requestSuffix}`, `${type}${successSuffix}`, `${type}${errorSuffix}`];
   } else if (typeof action.types !== 'undefined') {
     types = action.types;
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {
 
 export {
   getActionTypes,
+  REQUEST_SUFFIX,
   ERROR_SUFFIX,
   SUCCESS_SUFFIX,
 } from './getActionTypes';

--- a/test/getActionTypes.js
+++ b/test/getActionTypes.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { getActionTypes, SUCCESS_SUFFIX, ERROR_SUFFIX } from './../src/getActionTypes';
+import { getActionTypes, REQUEST_SUFFIX, SUCCESS_SUFFIX, ERROR_SUFFIX } from './../src/getActionTypes';
 
 describe('getActionTypes', () => {
 
@@ -7,7 +7,7 @@ describe('getActionTypes', () => {
     const action = {type:'TYPE'};
     const types = getActionTypes(action);
     expect(types).to.be.array;
-    expect(types[0]).to.equal(action.type);
+    expect(types[0]).to.equal(`${action.type}${REQUEST_SUFFIX}`);
     expect(types[1]).to.equal(`${action.type}${SUCCESS_SUFFIX}`);
     expect(types[2]).to.equal(`${action.type}${ERROR_SUFFIX}`);
   });
@@ -33,11 +33,20 @@ describe('getActionTypes', () => {
       expect(getActionTypes.bind(null,action)).to.throw(Error, /types/, /type/);
   });
 
+  it('should use custom request sufix if defined', () => {
+    const action = {type:'TYPE'};
+    const types = getActionTypes(action, {requestSuffix:'_STARTING'});
+    expect(types).to.be.array;
+    expect(types[0]).to.equal(`${action.type}_STARTING`);
+    expect(types[1]).to.equal(`${action.type}${SUCCESS_SUFFIX}`);
+    expect(types[2]).to.equal(`${action.type}${ERROR_SUFFIX}`);
+  });
+
   it('should use custom success sufix if defined', () => {
     const action = {type:'TYPE'};
     const types = getActionTypes(action, {successSuffix:'_AWESOME'});
     expect(types).to.be.array;
-    expect(types[0]).to.equal(action.type);
+    expect(types[0]).to.equal(`${action.type}${REQUEST_SUFFIX}`);
     expect(types[1]).to.equal(`${action.type}_AWESOME`);
     expect(types[2]).to.equal(`${action.type}${ERROR_SUFFIX}`);
   });
@@ -46,7 +55,7 @@ describe('getActionTypes', () => {
     const action = {type:'TYPE'};
     const types = getActionTypes(action, {errorSuffix:'_OH_NO'});
     expect(types).to.be.array;
-    expect(types[0]).to.equal(action.type);
+    expect(types[0]).to.equal(`${action.type}${REQUEST_SUFFIX}`);
     expect(types[1]).to.equal(`${action.type}${SUCCESS_SUFFIX}`);
     expect(types[2]).to.equal(`${action.type}_OH_NO`);
   });
@@ -54,11 +63,12 @@ describe('getActionTypes', () => {
   it('should use custom success and error sufix if defined', () => {
     const action = {type:'TYPE'};
     const types = getActionTypes(action,{
+      requestSuffix: '_STARTING',
       successSuffix:'_AWESOME',
       errorSuffix:'_OH_NO'
     });
     expect(types).to.be.array;
-    expect(types[0]).to.equal(action.type);
+    expect(types[0]).to.equal(`${action.type}_STARTING`);
     expect(types[1]).to.equal(`${action.type}_AWESOME`);
     expect(types[2]).to.equal(`${action.type}_OH_NO`);
   });


### PR DESCRIPTION
Thanks for this great library!

When implementing a loading reducer I found I needed to easily identify and target dispatched request actions from successes, failures and others. For example, by appending "_REQUEST" in the same way this middleware does for success and fail.

So this PR adds the ability to optionally set a suffix on all request actions. By default it leaves the type unchanged.