### PR TITLE
Fix of readme, EOF was a codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ let store = createStore(
     ...
   )
 )
-
+```
 
 
 ## Examples


### PR DESCRIPTION
The end of readme was a codeblock so Example License and Acknowledgements wasent encoded correctly.